### PR TITLE
Add html5 specific tag support

### DIFF
--- a/lib/html_sanitize_ex/scrubber/html5.ex
+++ b/lib/html_sanitize_ex/scrubber/html5.ex
@@ -32,6 +32,7 @@ defmodule HtmlSanitizeEx.Scrubber.HTML5 do
   Meta.allow_tag_with_uri_attributes   "a", ["href"], @valid_schemes
   Meta.allow_tag_with_these_attributes "a", ["accesskey", "class", "contenteditable", "contextmenu", "dir", "draggable", "dropzone", "hidden", "id", "inert", "itemid", "itemprop", "itemref", "itemscope", "itemtype", "lang", "role", "spellcheck", "tabindex", "title", "translate",
                                               "target", "ping", "rel", "media", "hreflang", "type"]
+  Meta.allow_tag_with_these_attributes "article", ["accesskey", "class", "contenteditable", "contextmenu", "dir", "draggable", "dropzone", "hidden", "id", "inert", "itemid", "itemprop", "itemref", "itemscope", "itemtype", "lang", "role", "spellcheck", "tabindex", "title", "translate"]
 
   Meta.allow_tag_with_these_attributes "b", ["accesskey", "class", "contenteditable", "contextmenu", "dir", "draggable", "dropzone", "hidden", "id", "inert", "itemid", "itemprop", "itemref", "itemscope", "itemtype", "lang", "role", "spellcheck", "tabindex", "title", "translate"]
 


### PR DESCRIPTION
[Quote from original PR](https://github.com/rrrene/html_sanitize_ex/pull/35):
> Currently `HtmlSanitizeEx.html5("<article>1</article>")` returns `"1"`.
> This is wrong because `<article>` is valid html attribute. Same with `<aside>` and `<footer>`.

